### PR TITLE
데이터 테이블 넓이 고정, 스크롤 위치 클래스 추가

### DIFF
--- a/src/pages/CreateProject/CreateProject.scss
+++ b/src/pages/CreateProject/CreateProject.scss
@@ -145,14 +145,26 @@
         .v-btn--outlined {
             &::before {
                 display: none;
-              }
+            }
         }
-
     }
 
 }
 .import-file-table {
     position: relative;
+    width: calc(100% - 400px);
+
+    .full-height {
+        &.v-data-table,
+        .v-data-table__wrapper{
+            height: 100%;
+        }
+    }
+    .v-data-table-header {
+        span {
+            white-space: nowrap;
+        }
+     }
 }
 .parse-data{
     color: $primary;

--- a/src/pages/CreateProject/ParseCSV.vue
+++ b/src/pages/CreateProject/ParseCSV.vue
@@ -3,13 +3,18 @@
     <div class="create-project parse-data">
         <v-row class="d-flex justify-start column-flex">
             <v-col class="import-file-table">
+
+                <!-- scroll 위치 :  full-height  
+                    full-height 사용시 : 높이 100% 로 스크롤이 바닥에 붙음
+                    full-height 미사용시 : 스크롤이 테이블에 따라 붙어 있음
+                  -->
                 <v-data-table
                     :headers="headers"
                     :items="desserts"
                     :items-per-page="8"
                     hide-default-footer
                     disable-sort
-                    class="elevation-0 base-table"
+                    class="elevation-0 base-table full-height"
                 ></v-data-table>            
             </v-col>
 
@@ -48,6 +53,28 @@
           { text: '장서수', value: 'th06' },
           { text: '방문자수', value: 'th07' },
           { text: '대출지수', value: 'th08' },
+          { text: 'All', value: 'th09' },
+          { text: '도서관 구분', value: 'th10' },
+          { text: '도서관 코드', value: 'th11' },
+          { text: '면적', value: 'th12' },
+          { text: '시구군', value: 'th13' },
+          { text: '장서수', value: 'th14' },
+          { text: '방문자수', value: 'th15' },
+          { text: '대출지수', value: 'th16' },
+          { text: 'All', value: 'th17' },
+          { text: '도서관 구분', value: 'th18' },
+          { text: '도서관 코드', value: 'th19' },
+          { text: '면적', value: 'th20' },
+          { text: '시구군', value: 'th21' },
+          { text: '장서수', value: 'th22' },
+          { text: '방문자수', value: 'th23' },
+          { text: '대출지수', value: 'th24' },
+          { text: '도서관 구분', value: 'th25' },
+          { text: '도서관 코드', value: 'th26' },
+          { text: '면적', value: 'th27' },
+          { text: '시구군', value: 'th28' },
+          { text: '장서수', value: 'th29' },
+          { text: '방문자수', value: 'th30' },
         ],
         desserts: [
           {
@@ -60,85 +87,31 @@
             th06: 3900,
             th07: 3915,
             th08: 9360,
+            th09: '1',
+            th10: '2014',
+            th11: 'LIVTYPE002',
+            th12: 526  ,
+            th13: '20,104',
+            th14: '서울 성북구',
+            th15: 3900,
+            th16: 3915,
+            th17: 9360,
+            th18: '1',
+            th19: '2014',
+            th20: 'LIVTYPE002',
+            th21: 526  ,
+            th22: '20,104',
+            th23: '서울 성북구',
+            th24: 3900,
+            th25: 3915,
+            th26: 9360,
+            th27: '1',
+            th28: '2014',
+            th29: 'LIVTYPE002',
+            th30: 526  ,
+
           },
-          {
-            th00: '2',
-            th01: '2014',
-            th02: 'LIVTYPE002',
-            th03: 526  ,
-            th04: '20,104',
-            th05: '서울 성북구',
-            th06: 3900,
-            th07: 3915,
-            th08: 9360,
-          },
-          {
-            th00: '3',
-            th01: '2014',
-            th02: 'LIVTYPE002',
-            th03: 526  ,
-            th04: '20,104',
-            th05: '서울 성북구',
-            th06: 3900,
-            th07: 3915,
-            th08: 9360,
-          },
-          {
-            th00: '4',
-            th01: '2014',
-            th02: 'LIVTYPE002',
-            th03: 526  ,
-            th04: '20,104',
-            th05: '서울 성북구',
-            th06: 3900,
-            th07: 3915,
-            th08: 9360,
-          },
-          {
-            th00: '5',
-            th01: '2014',
-            th02: 'LIVTYPE002',
-            th03: 526  ,
-            th04: '20,104',
-            th05: '서울 성북구',
-            th06: 3900,
-            th07: 3915,
-            th08: 9360,
-          },
-          {
-            th00: '6',
-            th01: '2014',
-            th02: 'LIVTYPE002',
-            th03: 526  ,
-            th04: '20,104',
-            th05: '서울 성북구',
-            th06: 3900,
-            th07: 3915,
-            th08: 9360,
-          },
-          {
-            th00: '7',
-            th01: '2014',
-            th02: 'LIVTYPE002',
-            th03: 526  ,
-            th04: '20,104',
-            th05: '서울 성북구',
-            th06: 3900,
-            th07: 3915,
-            th08: 9360,
-          },
-          {
-            th00: '8',
-            th01: '2014',
-            th02: 'LIVTYPE002',
-            th03: 526  ,
-            th04: '20,104',
-            th05: '서울 성북구',
-            th06: 3900,
-            th07: 3915,
-            th08: 9360,
-          },
- 
+      
         ],
       }
     },        


### PR DESCRIPTION
**데이터 테이블 위치 고정**
- 전체 넓이 에서 사이드 패널 만큼의 넓이를 빼 아래로 떨어지는 문제 해결

**테이블 스크롤 위치 클래스 추가 : full-height**
- full-height 사용시 : 높이 100% 로 스크롤이 바닥에 붙음
- full-height 미사용시 : 스크롤이 테이블에 따라 붙어 있음

**작업 확인**
path: /ParseCSV
